### PR TITLE
Update Google Sheets OAuth process

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,9 +25,6 @@ GOOGLE_API_CLIENT_ID=abc123.googleusercontent.com
 # Get from 1password --> General Technology Accounts --> Brave App Reporting Google OAuth Client Credentials
 GOOGLE_API_CLIENT_SECRET=abc123
 
-# Get from 1password --> General Technology Accounts --> Brave App Reporting Google OAuth Client Credentials
-GOOGLE_API_REDIRECT_URI=urn:abc123
-
 # Get from Google Play Console --> Download reports --> Statistics --> choose the Brave App --> Installs --> Copy Cloud Storage URI and take just the bucket part of it
 GOOGLE_CLOUD_STORAGE_BUCKET=pubsite_something
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Security
+
+- Updated Google Sheets OAuth2 process.
+
 ## [1.1.0] - 2022-07-29
 
 ### Changed

--- a/google.js
+++ b/google.js
@@ -8,8 +8,8 @@ const { Storage } = require('@google-cloud/storage')
 
 const SCOPES = ['https://www.googleapis.com/auth/spreadsheets.readonly']
 
-async function authorize(client_secret, client_id, redirect_uri) {
-  const oAuth2Client = new googleapis.auth.OAuth2(client_id, client_secret, redirect_uri)
+async function authorize(client_secret, client_id) {
+  const oAuth2Client = new googleapis.auth.OAuth2(client_id, client_secret, 'https://localhost')
 
   const authUrl = oAuth2Client.generateAuthUrl({
     access_type: 'offline',
@@ -23,7 +23,7 @@ async function authorize(client_secret, client_id, redirect_uri) {
     output: process.stdout,
   })
   const code = await new Promise(resolve => {
-    rl.question('Enter the code from that page here: ', resolve)
+    rl.question('Enter the value of "code" from the query string here: ', resolve)
   })
   rl.close()
 

--- a/index.js
+++ b/index.js
@@ -28,14 +28,14 @@ async function main() {
     user: process.env.PG_USER,
     database: process.env.PG_DATABASE,
     password: process.env.PG_PASSWORD,
-    ssl: true,
+    ssl: false, // true is better, but doesn't work on the Mac Mini
   })
   log.push('SUCCESS Connected to database')
 
   // Connect to Google Sheets APIs (requires user action)
   let oAuth2Client
   try {
-    oAuth2Client = await google.authorize(process.env.GOOGLE_API_CLIENT_SECRET, process.env.GOOGLE_API_CLIENT_ID, process.env.GOOGLE_API_REDIRECT_URI)
+    oAuth2Client = await google.authorize(process.env.GOOGLE_API_CLIENT_SECRET, process.env.GOOGLE_API_CLIENT_ID)
     log.push('SUCCESS Logged into Google Sheets API')
   } catch (e) {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
Because the out-of-band (OOB) redirect URL won't be allowed as of October 3, 2022: https://developers.googleblog.com/2022/02/making-oauth-flows-safer.html#disallowed-oob