### PR TITLE
Add Android and Apple data for whitelabel clients

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,13 +19,6 @@ GOOGLE_API_CLIENT_ID=abc123.googleusercontent.com
 # Get from 1password --> General Technology Accounts --> Brave App Reporting Google OAuth Client Credentials
 GOOGLE_API_CLIENT_SECRET=abc123
 
-# Get from Google Play Console --> Download reports --> Statistics --> choose the Brave App --> Installs --> Copy Cloud Storage URI and take just the bucket part of it
-GOOGLE_CLOUD_STORAGE_BUCKET=pubsite_something
-
-# Get from Google Play Console --> Download reports --> Statistics --> choose the Brave App --> Installs --> Inspect one of the download links to get the path and name of the CSV file
-# Start with the word after the bucket name (no forward slash) and end just before the date
-GOOGLE_CLOUD_STORAGE_FILE_PREFIX=stats/installs/installs_app.path_
-
 # DO NOT change the name of this variable, it must be like this in order for the Google API to pick it up
 # Get JSON file from 1Password --> General Technology Accounts --> Brave App Reporting Google Application Credentials and set this to the path to that JSON file
 # Originally from https://console.cloud.google.com --> Brave App Reporting Script --> IAM & Admin --> Service Accounts --> Manage Keys --> Add Key

--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,3 @@ GOOGLE_APPLICATION_CREDENTIALS=/full/path/to/credentials.json
 
 # The ID from the URL of the Google Sheet called "Updated Call Log (Brave App) (Responses)"
 SUPPORTER_LOG_GOOGLE_SHEET_ID=abc123
-
-# Apple App ID from App Store Connect --> The Brave App --> General --> App Inforomation --> Apple ID
-APPLE_APP_ID=123456789

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ the code was deployed.
 
 - Download and store the Android download data for whitelabel clients.
 - Download and store the Apple download data for whitelabel clients.
+- As much time series data as I could from the Apple App store and stored it in `apple_data` table.
+
+### Changed
+
+- Renamed the `appledownloads` table to `apple_data` and two of its columns (`download_date` is now `data_data` and `download_count` is now `first_time_downloads_count`).
 
 ## [2.1.0] - 2023-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ the code was deployed.
 ## Added
 
 - Download and store the Android download data for whitelabel clients.
+- Download and store the Apple download data for whitelabel clients.
 
 ## [2.1.0] - 2023-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## [Unreleased]
 
+## Added
+
+- Download and store the Android download data for whitelabel clients.
+
 ## [2.1.0] - 2023-04-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Scripts to help with Brave App reporting
    - `twilioToken` - Get from Twilio --> Accounts --> Brave App - Production --> View Subaccounts --> [Name of the subaccount for the whitelabel client] --> Account Info --> Auth Token (example: `c8f0a844ca87d7c436e76dfcc53cd62e`)
    - `googleCloudStorageBucket` - Get from Google Play Console --> Download reports --> Statistics --> choose the whitelabel client's app --> Installs --> Copy Cloud Storage URI and take just the bucket part of it (example: `pubsite_prod_rev_12345678901234567890`)
    - `googleCloudStorageFilePrefix` - Get from Google Play Console --> Download reports --> Statistics --> choose the whitelabel client's app --> Installs --> Inspect one of the download links to get the path and name of the CSV file. Start with the word after the bucket name (no forward slash) and end just before the date (example: `stats/installs/installs_com.package.name_`)
+   - `appleAppId` - Get from Apple App ID from App Store Connect --> My Apps --> [Name of the whitelabel client's app] --> General --> App Inforomation --> Apple ID (example: `1234567890`)
 
 1. Run `npm ci`
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Scripts to help with Brave App reporting
 
 1. Copy the `clients.json.example` file, rename the copy to `clients.json`, and update it to have the values you need
 
+   - `name` - Human-readable name for the whitelabel client
+   - `twilioSid` - Get from Twilio --> Accounts --> Brave App - Production --> View Subaccounts --> [Name of the subaccount for the whitelabel client] --> Account Info --> Account SID (example: `ACec68cccba2aa5443c2b171336fe86a70`)
+   - `twilioToken` - Get from Twilio --> Accounts --> Brave App - Production --> View Subaccounts --> [Name of the subaccount for the whitelabel client] --> Account Info --> Auth Token (example: `c8f0a844ca87d7c436e76dfcc53cd62e`)
+   - `googleCloudStorageBucket` - Get from Google Play Console --> Download reports --> Statistics --> choose the whitelabel client's app --> Installs --> Copy Cloud Storage URI and take just the bucket part of it (example: `pubsite_prod_rev_12345678901234567890`)
+   - `googleCloudStorageFilePrefix` - Get from Google Play Console --> Download reports --> Statistics --> choose the whitelabel client's app --> Installs --> Inspect one of the download links to get the path and name of the CSV file. Start with the word after the bucket name (no forward slash) and end just before the date (example: `stats/installs/installs_com.package.name_`)
+
 1. Run `npm ci`
 
 1. Run `npm start`

--- a/apple.js
+++ b/apple.js
@@ -6,7 +6,55 @@ const readline = require('readline')
 
 const url = 'https://appstoreconnect.apple.com/analytics/api/v1/data/time-series'
 
-async function getAppleFirstTimeDownloads(appId) {
+async function downloadAppleMetrics(appId, cookies, measures) {
+  const appleMetrics = {}
+
+  for (const measure of measures) {
+    const response = await axios({
+      method: 'post',
+      url,
+      data: {
+        adamId: [appId],
+        measures: [measure], // Although this is an array, it will complain if I put more than two mesures in here while I am grouping by "storefront"
+        frequency: 'day',
+        startTime: '2018-09-01T00:00:00Z', // Month where we first have Brave App data. If this step starts to take too long, this can be reduced as long as this earlier data is already in the DB
+        endTime: `${new Date().toISOString().substring(0, 10)}T00:00:00Z`,
+        group: {
+          metric: measure,
+          dimension: 'storefront', // This is what groups it by Territory
+          rank: 'DESCENDING',
+          limit: 10,
+        },
+      },
+      headers: {
+        Host: 'appstoreconnect.apple.com',
+        'X-Requested-By': 'dev.apple.com',
+        Cookie: cookies,
+        'Content-Type': 'application/json',
+      },
+    })
+
+    for (const results of response.data.results) {
+      const territoryName = results.group.title
+      if (results.meetsThreshold) {
+        for (const data of results.data) {
+          const formattedDate = data.date.substring(0, 10)
+          const key = [formattedDate, territoryName].join('_')
+          if (appleMetrics[key] === undefined) {
+            appleMetrics[key] = { territoryName, date: formattedDate }
+          }
+          appleMetrics[key][measure] = data[measure]
+        }
+      }
+    }
+
+    await new Promise(r => setTimeout(r, 5000)) // Sleep to avoid rate limiting
+  }
+
+  return appleMetrics
+}
+
+async function getAllAppleData(appId) {
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout,
@@ -20,33 +68,24 @@ async function getAppleFirstTimeDownloads(appId) {
   })
   rl.close()
 
-  const response = await axios({
-    method: 'post',
-    url,
-    data: {
-      adamId: [appId],
-      measures: ['units'],
-      frequency: 'day',
-      startTime: '2018-09-01T00:00:00Z', // Month where we first have Brave App data
-      endTime: `${new Date().toISOString().substring(0, 10)}T00:00:00Z`,
-      group: {
-        metric: 'units',
-        dimension: 'storefront',
-        rank: 'DESCENDING',
-        limit: 10,
-      },
-    },
-    headers: {
-      Host: 'appstoreconnect.apple.com',
-      'X-Requested-By': 'dev.apple.com',
-      Cookie: cookies,
-      'Content-Type': 'application/json',
-    },
-  })
-
-  return response.data.results
+  return await downloadAppleMetrics(appId, cookies, [
+    'impressionsTotal',
+    'impressionsTotalUnique',
+    'conversionRate',
+    'pageViewCount',
+    'pageViewUnique',
+    'updates',
+    'units',
+    'redownloads',
+    'totalDownloads',
+    'installs',
+    'sessions',
+    'activeDevices',
+    'rollingActiveDevices',
+    'uninstalls',
+  ])
 }
 
 module.exports = {
-  getAppleFirstTimeDownloads,
+  getAllAppleData,
 }

--- a/apple.js
+++ b/apple.js
@@ -12,7 +12,9 @@ async function getAppleFirstTimeDownloads(appId) {
     output: process.stdout,
   })
   // eslint-disable-next-line no-console
-  console.log('Authorize this app by visiting this url and logging in using your Apple ID: https://appstoreconnect.apple.com/login')
+  console.log(
+    "Authorize this app by visiting this url, logging in using your Apple ID: https://appstoreconnect.apple.com/login, and selecting the whitelabel client's account",
+  )
   const cookies = await new Promise(resolve => {
     rl.question('Copy all the cookies sent to "/providerNews" from the Developer Console Network tab and enter them here : ', resolve)
   })

--- a/clients.json.example
+++ b/clients.json.example
@@ -5,6 +5,7 @@
     "twilioToken": "xyz987"
     "googleCloudStorageBucket": "pubsite_prod_rev_01234567890123456789",
     "googleCloudStorageFilePrefix": "stats/installs/installs_com.package.name_",
+    "appleAppId": "1234567890"
   },
   {
     "name": "Client2",
@@ -12,5 +13,6 @@
     "twilioToken": null,
     "googleCloudStorageBucket": null,
     "googleCloudStorageFilePrefix": null,
+    "appleAppId": null
   }
 ]

--- a/clients.json.example
+++ b/clients.json.example
@@ -3,10 +3,14 @@
     "name": "Brave",
     "twilioSid": "abc123",
     "twilioToken": "xyz987"
+    "googleCloudStorageBucket": "pubsite_prod_rev_01234567890123456789",
+    "googleCloudStorageFilePrefix": "stats/installs/installs_com.package.name_",
   },
   {
     "name": "Client2",
-    "twilioSid": "abc123Client2",
-    "twilioToken": "xyz987Client2"
+    "twilioSid": null,
+    "twilioToken": null,
+    "googleCloudStorageBucket": null,
+    "googleCloudStorageFilePrefix": null,
   }
 ]

--- a/db/007-store-more-apple-data.sql
+++ b/db/007-store-more-apple-data.sql
@@ -1,0 +1,68 @@
+DO $migration$
+    DECLARE migrationId INT;
+    DECLARE lastSuccessfulMigrationId INT;
+BEGIN
+    -- The migration ID of this file
+    migrationId := 7;
+
+    -- Get the migration ID of the last file to be successfully run
+    SELECT MAX(id) INTO lastSuccessfulMigrationId
+    FROM migrations;
+
+    -- Only execute this script if its migration ID is next after the last successful migration ID
+    IF migrationId - lastSuccessfulMigrationId = 1 THEN
+        -- ADD SCRIPT HERE
+        ALTER TABLE appledownloads
+        RENAME TO apple_data;
+
+        ALTER TABLE apple_data
+        RENAME COLUMN download_count TO first_time_downloads_count;
+
+        ALTER TABLE apple_data
+        RENAME COLUMN download_date TO data_date;
+
+        ALTER TABLE apple_data
+        ADD COLUMN IF NOT EXISTS redownloads_count INTEGER;
+
+        ALTER TABLE apple_data
+        ADD COLUMN IF NOT EXISTS total_downloads_count INTEGER;
+
+        ALTER TABLE apple_data
+        ADD COLUMN IF NOT EXISTS total_device_impressions_count INTEGER;
+
+        ALTER TABLE apple_data
+        ADD COLUMN IF NOT EXISTS unique_device_impressions_count INTEGER;
+
+        ALTER TABLE apple_data
+        ADD COLUMN IF NOT EXISTS total_product_page_views_count INTEGER;
+
+        ALTER TABLE apple_data
+        ADD COLUMN IF NOT EXISTS unique_product_page_views_count INTEGER;
+
+        ALTER TABLE apple_data
+        ADD COLUMN IF NOT EXISTS updates_count INTEGER;
+
+        ALTER TABLE apple_data
+        ADD COLUMN IF NOT EXISTS conversion_rate REAL;
+
+        ALTER TABLE apple_data
+        ADD COLUMN IF NOT EXISTS installations_count INTEGER;
+
+        ALTER TABLE apple_data
+        ADD COLUMN IF NOT EXISTS sessions_count INTEGER;
+
+        ALTER TABLE apple_data
+        ADD COLUMN IF NOT EXISTS total_active_devices_count INTEGER;
+
+        ALTER TABLE apple_data
+        ADD COLUMN IF NOT EXISTS active_in_last_30_days_devices_count INTEGER;
+
+        ALTER TABLE apple_data
+        ADD COLUMN IF NOT EXISTS deletions_count INTEGER;
+
+        -- Update the migration ID of the last file to be successfully run to the migration ID of this file
+        INSERT INTO migrations (id)
+        VALUES (migrationId);
+    END IF;
+END $migration$;
+

--- a/google.js
+++ b/google.js
@@ -63,18 +63,18 @@ function formatLowercaseString(value) {
   return value.trim().toLowerCase()
 }
 
-async function getAndroidDownloads() {
+async function getAndroidDownloads(googleCloudStorageBucket, googleCloudStoragePrefix) {
   // Get the names of all the download statistics reports for the Brave App
   const storage = new Storage()
-  const [files] = await storage.bucket(process.env.GOOGLE_CLOUD_STORAGE_BUCKET).getFiles({
-    prefix: process.env.GOOGLE_CLOUD_STORAGE_FILE_PREFIX,
+  const [files] = await storage.bucket(googleCloudStorageBucket).getFiles({
+    prefix: googleCloudStoragePrefix,
   })
 
   // Read all the downloads-by-country files, split the results into rows, and add to the results array
   const results = []
   const countryFileNames = files.filter(f => f.name.indexOf('_country.csv') > 0).map(f => f.name)
   for (const countryFileName of countryFileNames) {
-    const [contents] = await storage.bucket(process.env.GOOGLE_CLOUD_STORAGE_BUCKET).file(countryFileName).download()
+    const [contents] = await storage.bucket(googleCloudStorageBucket).file(countryFileName).download()
     contents
       .toString('utf16le') // decode Buffer
       .split('\n') // split into rows

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ async function main() {
   // Setup clients
   const clientsRaw = await fs.readFile('clients.json', 'ascii')
   const clients = JSON.parse(clientsRaw)
-  log.push('SUCCESS imported clients.json')
+  log.push('SUCCESS Imported clients.json')
 
   // Connect to destination database
   const pool = new pg.Pool({
@@ -48,7 +48,7 @@ async function main() {
   // Get Supporter Logs from Google Sheets
   // Reference: https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/get
   // eslint-disable-next-line no-console
-  console.log('Inserting supporter logs. This takes less than 1 minute...')
+  console.log('Inserting supporter logs (Brave). This takes less than 1 minute...')
   const LOG_TIMESTAMP = 0
   const SUPPORTER_EMAIL = 1
   const CALL_DATE = 3
@@ -124,10 +124,10 @@ async function main() {
     }
 
     await Promise.all(queries)
-    log.push('SUCCESS Stored supporter call logs from Google Sheets')
+    log.push('SUCCESS Stored supporter call logs from Google Sheets (Brave)')
   } catch (e) {
     // eslint-disable-next-line no-console
-    console.error('Error getting the updated call logs from Google Sheets and storing them in the DB', e)
+    console.error('Error getting the updated call logs from Google Sheets and storing them in the DB (Brave)', e)
     log.push('FAIL    Did not store the supporter call logs from Google Sheets')
   }
 
@@ -141,7 +141,7 @@ async function main() {
   // eslint-disable-next-line no-console
   for (const client of clients) {
     if (client.googleCloudStorageBucket === null || client.googleCloudStorageFilePrefix === null) {
-      log.push(`skipped Did not store the Android user downloads (${client.name})`)
+      log.push(`skip    Did not store the Android user downloads (${client.name})`)
       continue
     }
 
@@ -176,16 +176,16 @@ async function main() {
       console.error(`Error getting the Android user downloads and storing them in the DB (${client.name})`, e)
       log.push(`FAIL    Did not store the Android user downloads (${client.name})`)
     }
-  }
 
-  // eslint-disable-next-line no-console
-  console.log('\n\n')
+    // eslint-disable-next-line no-console
+    console.log('\n\n')
+  }
 
   // Get Apple Connect first time downloads stats by territory (requires user action)
   // eslint-disable-next-line no-console
   for (const client of clients) {
     if (client.appleAppId === null) {
-      log.push(`skipped Did not store the Apple First Time Downloads (${client.name})`)
+      log.push(`skip    Did not store the Apple First Time Downloads (${client.name})`)
       continue
     }
 
@@ -223,17 +223,17 @@ async function main() {
       console.error(`Error getting the Apple First Time Downloads and storing them in the DB (${client.name})`, e)
       log.push(`FAIL    Did not store the Apple First Time Downloads (${client.name})`)
     }
-  }
 
-  // eslint-disable-next-line no-console
-  console.log('\n\n')
+    // eslint-disable-next-line no-console
+    console.log('\n\n')
+  }
 
   // Get Twilio call logs for the last 13 months
   // Reference: https://www.twilio.com/docs/libraries/node#iterate-through-records
   // eslint-disable-next-line no-console
   for (const client of clients) {
     if (client.twilioSid === null || client.twilioToken === null) {
-      log.push(`skipped Did not store the Twilio call logs (${client.name})`)
+      log.push(`skip    Did not store the Twilio call logs (${client.name})`)
       continue
     }
 

--- a/index.js
+++ b/index.js
@@ -221,10 +221,15 @@ async function main() {
   // eslint-disable-next-line no-console
   console.log('\n\n')
 
+  // Get Twilio call logs for the last 13 months
+  // Reference: https://www.twilio.com/docs/libraries/node#iterate-through-records
+  // eslint-disable-next-line no-console
   for (const client of clients) {
-    // Get Twilio call logs for the last 13 months
-    // Reference: https://www.twilio.com/docs/libraries/node#iterate-through-records
-    // eslint-disable-next-line no-console
+    if (client.twilioSid === null || client.twilioToken === null) {
+      log.push(`skipped Did not store the Twilio call logs (${client.name})`)
+      continue
+    }
+
     console.log(`Inserting Twilio calls (${client.name}) for the last 13 months. This can take about 10 minutes...`)
     try {
       const twilioClient = twilio(client.twilioSid, client.twilioToken)
@@ -268,7 +273,7 @@ async function main() {
     } catch (e) {
       // eslint-disable-next-line no-console
       console.error(`Error getting the Twilio calls (${client.name}) and storing them in the DB`, e)
-      log.push(`FAIL    Did not store the Twilio call logs ${client.name}`)
+      log.push(`FAIL    Did not store the Twilio call logs (${client.name})`)
     }
   }
 


### PR DESCRIPTION
Moved client-specific config from `.env` to `clients.json`. This is so that for each thing, I can just iterate over the clients.json to get what we need to do. Any values that are `null` will just be skipped.

Shel requested that we retrieve more of the Apple App Store data because it will be useful for her when investigating things. The Sales data wasn't interesting, so we didn't grab that. And the Crashes data wasn't available grouped by Territory, so it wouldn't have naturally fit into the `apple_data` table, so I left that out as well.

There does appear to be some API rate limiting going on through the Apple App Store API. So I've added a 5-second sleep between each call. This appears to have fixed the issue.

## Test Plan
- [x] Run script locally
- [x] Compare a few days' data against the UI for each of the whitelabel clients
- [x] Shel thinks that it looks OK